### PR TITLE
fix: pin to lodash 4.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,11 @@
   "files": [
     "dist"
   ],
+  "pnpm": {
+    "overrides": {
+      "lodash": "4.18.1"
+    }
+  },
   "n8n": {
     "n8nNodesApiVersion": 1,
     "credentials": [

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "pnpm": {
     "overrides": {
-      "lodash": "4.18.1"
+      "lodash": ">=4.18.1"
     }
   },
   "n8n": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  lodash: 4.18.1
+
 importers:
 
   .:
@@ -1167,8 +1170,8 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
@@ -1857,7 +1860,7 @@ snapshots:
       isolated-vm: 6.1.2
       js-base64: 3.7.2
       jssha: 3.3.1
-      lodash: 4.17.23
+      lodash: 4.18.1
       luxon: 3.7.2
       md5: 2.3.0
       title-case: 3.0.3
@@ -2876,7 +2879,7 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
-  lodash@4.17.23: {}
+  lodash@4.18.1: {}
 
   lower-case@2.0.2:
     dependencies:
@@ -2936,7 +2939,7 @@ snapshots:
       js-base64: 3.7.2
       jsonrepair: 3.13.2
       jssha: 3.3.1
-      lodash: 4.17.23
+      lodash: 4.18.1
       luxon: 3.7.2
       md5: 2.3.0
       recast: 0.22.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  lodash: 4.18.1
+  lodash: '>=4.18.1'
 
 importers:
 


### PR DESCRIPTION
To fix the critical akido security alarm (see linear ticket).

note that this does not affect any users installing our package, and also doesn't require us to publish a new version, since the package.json specifies `n8n-workflow` as a peerDependency and we allow any version for it.
Meaning it is up to the user to update `n8n-workflow` to later fix this security on their end (once n8n-workflow has published a version which has fixed this error. Right now they haven't)

Please correct me in my understanding of package.json's and peerDependencies but Codex and I agree that this PR only fixes the local installation of this repo and the security alert, but that we in fact can do nothing for our end users of the package