### PR TITLE
chore(deps): update n8n-workflow to 2.16 and pin zod to 4.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   ],
   "pnpm": {
     "overrides": {
+      "n8n-workflow@2.16.0>lodash": ">=4.18.1",
       "n8n-workflow@2.16.0>zod": ">=4.4.0"
     }
   },

--- a/package.json
+++ b/package.json
@@ -34,9 +34,8 @@
   ],
   "pnpm": {
     "overrides": {
-      "@n8n/expression-runtime@0.8.0>lodash": ">=4.18.1",
-      "n8n-workflow@2.16.0>lodash": ">=4.18.1",
-      "n8n-workflow@2.16.0>zod": ">=4.4.0"
+      "lodash": ">=4.18.1",
+      "zod": ">=4.4.0"
     }
   },
   "n8n": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "pnpm": {
     "overrides": {
-      "lodash": ">=4.18.1"
+      "n8n-workflow@2.16.0>zod": ">=4.4.0"
     }
   },
   "n8n": {
@@ -55,7 +55,8 @@
     "prettier": "^3.8.1",
     "prettier-plugin-organize-imports": "^4.3.0",
     "tsdown": "0.20.0-beta.1",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "n8n-workflow": "^2.16.0"
   },
   "peerDependencies": {
     "n8n-workflow": "*"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   ],
   "pnpm": {
     "overrides": {
+      "@n8n/expression-runtime@0.8.0>lodash": ">=4.18.1",
       "n8n-workflow@2.16.0>lodash": ">=4.18.1",
       "n8n-workflow@2.16.0>zod": ">=4.4.0"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@n8n/expression-runtime@0.8.0>lodash': '>=4.18.1'
-  n8n-workflow@2.16.0>lodash: '>=4.18.1'
-  n8n-workflow@2.16.0>zod: '>=4.4.0'
+  lodash: '>=4.18.1'
+  zod: '>=4.4.0'
 
 importers:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,15 +5,11 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  lodash: '>=4.18.1'
+  n8n-workflow@2.16.0>zod: '>=4.4.0'
 
 importers:
 
   .:
-    dependencies:
-      n8n-workflow:
-        specifier: '*'
-        version: 2.13.0
     devDependencies:
       '@typescript-eslint/parser':
         specifier: ~8.32.1
@@ -27,6 +23,9 @@ importers:
       gulp:
         specifier: ^5.0.1
         version: 5.0.1
+      n8n-workflow:
+        specifier: ^2.16.0
+        version: 2.16.0
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
@@ -127,8 +126,8 @@ packages:
   '@n8n/errors@0.6.0':
     resolution: {integrity: sha512-oVJ0lgRYJY6/aPOW2h37ea5T+nX7/wULRn5FymwYeaiYlsLdqwIQEtGwZrajpzxJB0Os74u4lSH3WWQgZCkgxQ==}
 
-  '@n8n/expression-runtime@0.5.0':
-    resolution: {integrity: sha512-DqkF79FyuljdjlSz1i6PfbrQ47w5U/fIqjoyAbRVxr+YatiM3RAe0zhfQ1ur1lV5QTq0BHnY8zsfFQ+DIItPhA==}
+  '@n8n/expression-runtime@0.8.0':
+    resolution: {integrity: sha512-SnBLoLsrGUCS9cVrF20UuSyKcMv+y6Clc4+EA9zLjX85S0GPwOAdApUVSsi81ejPAqMlm42TW1L6r7NpcK/ztQ==}
 
   '@n8n/tournament@1.0.6':
     resolution: {integrity: sha512-UGSxYXXVuOX0yL6HTLBStKYwLIa0+JmRKiSZSCMcM2s2Wax984KWT6XIA1TR/27i7yYpDk1MY14KsTPnuEp27A==}
@@ -1170,8 +1169,8 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
-  lodash@4.18.1:
-    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
@@ -1225,8 +1224,8 @@ packages:
     resolution: {integrity: sha512-32GSKM3Wyc8dg/p39lWPKYu8zci9mJFzV1Np9Of0ZEpe6Fhssn/FbI7ywAMd40uX+p3ZKh3T5EeCFv81qS3HmQ==}
     engines: {node: '>= 10.13.0'}
 
-  n8n-workflow@2.13.0:
-    resolution: {integrity: sha512-fYLyYDlenGlzNvC+i+xsiFSna7gZVbhhTTb215ygL7JVguJhWy7JqW8szhvxkJMqujP0ejlbJYzPfRVxNyllkQ==}
+  n8n-workflow@2.16.0:
+    resolution: {integrity: sha512-JoDvHLvV4QZQBCDVQl5xkrGOmPmsacLO4TkJkErCzMmiEqIej+h14J6eCUY7gbxBj8V+GIBlpqyO63akJbXRQg==}
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -1670,6 +1669,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8flags@4.0.1:
@@ -1752,8 +1752,8 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zod@3.25.67:
-    resolution: {integrity: sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -1854,13 +1854,13 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
-  '@n8n/expression-runtime@0.5.0':
+  '@n8n/expression-runtime@0.8.0':
     dependencies:
       '@n8n/tournament': 1.0.6
       isolated-vm: 6.1.2
       js-base64: 3.7.2
       jssha: 3.3.1
-      lodash: 4.18.1
+      lodash: 4.17.23
       luxon: 3.7.2
       md5: 2.3.0
       title-case: 3.0.3
@@ -2879,7 +2879,7 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
-  lodash@4.18.1: {}
+  lodash@4.17.23: {}
 
   lower-case@2.0.2:
     dependencies:
@@ -2926,10 +2926,10 @@ snapshots:
 
   mute-stdout@2.0.0: {}
 
-  n8n-workflow@2.13.0:
+  n8n-workflow@2.16.0:
     dependencies:
       '@n8n/errors': 0.6.0
-      '@n8n/expression-runtime': 0.5.0
+      '@n8n/expression-runtime': 0.8.0
       '@n8n/tournament': 1.0.6
       ast-types: 0.16.1
       callsites: 3.1.0
@@ -2939,7 +2939,7 @@ snapshots:
       js-base64: 3.7.2
       jsonrepair: 3.13.2
       jssha: 3.3.1
-      lodash: 4.18.1
+      lodash: 4.17.23
       luxon: 3.7.2
       md5: 2.3.0
       recast: 0.22.0
@@ -2947,7 +2947,7 @@ snapshots:
       transliteration: 2.3.5
       uuid: 10.0.0
       xml2js: 0.6.2
-      zod: 3.25.67
+      zod: 4.4.3
 
   natural-compare@1.4.0: {}
 
@@ -3516,4 +3516,4 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod@3.25.67: {}
+  zod@4.4.3: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@n8n/expression-runtime@0.8.0>lodash': '>=4.18.1'
   n8n-workflow@2.16.0>lodash: '>=4.18.1'
   n8n-workflow@2.16.0>zod: '>=4.4.0'
 
@@ -1170,9 +1171,6 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
-
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
@@ -1864,7 +1862,7 @@ snapshots:
       isolated-vm: 6.1.2
       js-base64: 3.7.2
       jssha: 3.3.1
-      lodash: 4.17.23
+      lodash: 4.18.1
       luxon: 3.7.2
       md5: 2.3.0
       title-case: 3.0.3
@@ -2882,8 +2880,6 @@ snapshots:
       p-locate: 5.0.0
 
   lodash.merge@4.6.2: {}
-
-  lodash@4.17.23: {}
 
   lodash@4.18.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  n8n-workflow@2.16.0>lodash: '>=4.18.1'
   n8n-workflow@2.16.0>zod: '>=4.4.0'
 
 importers:
@@ -1171,6 +1172,9 @@ packages:
 
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
@@ -2881,6 +2885,8 @@ snapshots:
 
   lodash@4.17.23: {}
 
+  lodash@4.18.1: {}
+
   lower-case@2.0.2:
     dependencies:
       tslib: 2.8.1
@@ -2939,7 +2945,7 @@ snapshots:
       js-base64: 3.7.2
       jsonrepair: 3.13.2
       jssha: 3.3.1
-      lodash: 4.17.23
+      lodash: 4.18.1
       luxon: 3.7.2
       md5: 2.3.0
       recast: 0.22.0


### PR DESCRIPTION
@tobiastrinks here the same game as in #20 but I had a look at your comment again from the old PR

>>>Maybe it makes sense to overwrite to a version range, but not sure whats best practice here: lodash: ">=4.18.0 <5"
Should we have a followup ticket that attempts to remove this overwrite in 2 weeks?
>>
>>Good point. I changed it to allow all versions higher than 4.18. That way we don't even need to remove it, because at some point it will just become obsolete.
>
>@8BitJonny
I thought so too, however it will always overwrite anything that n8n specifies. -> if in the future n8n specifies 4.19 because it does not support 4.20 yet, pnpm will still upgrade to 4.20 which is a breaking change again.
>
> I would suggest to have a follow-up ticket to remove the overwrite.

I still haven't done a follow up ticket (not for the last one or this one), since all these overrides are only affecting our repo and our installation of our dev dependencies. These don't have any consequences to the end user installing our library.
So I'd opt to just enforce a version that is higher than the vulnerable version and if, like you say, n8n-workflow or other dependency create a new version that explicitly require a version that we don't allow, (which I doubt is likely) then we'll get the version conflict or the breaking change and we'll act on it then. But I think for now this is the best approach. 
I also looked into overriding it via 
```
"n8n-workflow@2.16.0>lodash": ">=4.18.1",
```
but that also will likely result in us accidentally updating to a n8n workflow version that is not covered by the override but still has the vulnerable version

(also want to check why akido is not linting prs here)
